### PR TITLE
feat(git): enforce commit body and footer validation

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -25,7 +25,7 @@ branch=$(git rev-parse --abbrev-ref HEAD)
 ./node_modules/.bin/git-validator branch "$branch" || exit 1
 
 # Validate only the last commit (simpler, avoids old history issues)
-last_commit=$(git log -1 --pretty=format:%s)
+last_commit=$(git log -1 --pretty=format:%B)
 ./node_modules/.bin/git-validator commit "$last_commit" || exit 1
 
 echo "✅ Branch and last commit are valid. Push allowed!"
@@ -43,7 +43,7 @@ echo "🚀 Running git-validator pre-push..."
 ./node_modules/.bin/git-validator branch "$branch" || exit 1
 
 # Validate only the last commit
-last_commit=$(git log -1 --pretty=format:%s)
+last_commit=$(git log -1 --pretty=format:%B)
 ./node_modules/.bin/git-validator commit "$last_commit" || exit 1
 
 echo "✅ Branch and last commit are valid. Push allowed!"

--- a/dist/validators/commit.js
+++ b/dist/validators/commit.js
@@ -8,10 +8,19 @@ exports.validateCommitMessage = validateCommitMessage;
 const config_1 = require("../config");
 function validateCommitMessage(message) {
     const config = (0, config_1.loadConfig)();
+    const lines = message.split('\n');
+    const header = lines[0];
+    const body = lines.slice(1).join('\n');
+    if (/^(WIP|fixup!|squash!)/i.test(header)) {
+        return '❌ Invalid commit. Temporary commits (WIP, fixup!, squash!) are not allowed.';
+    }
     const types = config.commitTypes.join('|');
-    const regex = new RegExp(`^(${types})(\\([\\w\\-]+\\))?: .{1,${config.maxCommitLength}}$`);
-    if (!regex.test(message)) {
+    const headerRegex = new RegExp(`^(${types})(\\([\\w\\-]+\\))?: .{1,${config.maxCommitLength}}$`);
+    if (!headerRegex.test(message)) {
         return `❌ Invalid commit. Use the Conventional Commits pattern (e.g., feat: add login). Allowed types: ${config.commitTypes.join(', ')}. Max length: ${config.maxCommitLength}`;
+    }
+    if (/BREAKING CHANGE:/i.test(body)) {
+        return null;
     }
     return null;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,7 @@ branch=$(git rev-parse --abbrev-ref HEAD)
 ./node_modules/.bin/git-validator branch "$branch" || exit 1
 
 # Validate only the last commit (simpler, avoids old history issues)
-last_commit=$(git log -1 --pretty=format:%s)
+last_commit=$(git log -1 --pretty=format:%B)
 ./node_modules/.bin/git-validator commit "$last_commit" || exit 1
 
 echo "✅ Branch and last commit are valid. Push allowed!"
@@ -47,7 +47,7 @@ echo "🚀 Running git-validator pre-push..."
 ./node_modules/.bin/git-validator branch "$branch" || exit 1
 
 # Validate only the last commit
-last_commit=$(git log -1 --pretty=format:%s)
+last_commit=$(git log -1 --pretty=format:%B)
 ./node_modules/.bin/git-validator commit "$last_commit" || exit 1
 
 echo "✅ Branch and last commit are valid. Push allowed!"

--- a/src/validators/commit.ts
+++ b/src/validators/commit.ts
@@ -6,15 +6,28 @@ import { loadConfig } from '../config';
 
 export function validateCommitMessage(message: string): string | null {
   const config = loadConfig();
+
+  const lines = message.split('\n');
+  const header = lines[0];
+  const body = lines.slice(1).join('\n');
+
+  if (/^(WIP|fixup!|squash!)/i.test(header)) {
+    return '❌ Invalid commit. Temporary commits (WIP, fixup!, squash!) are not allowed.';
+  }
+
   const types = config.commitTypes.join('|');
-  const regex = new RegExp(
+  const headerRegex = new RegExp(
     `^(${types})(\\([\\w\\-]+\\))?: .{1,${config.maxCommitLength}}$`
   );
 
-  if (!regex.test(message)) {
+  if (!headerRegex.test(message)) {
     return `❌ Invalid commit. Use the Conventional Commits pattern (e.g., feat: add login). Allowed types: ${config.commitTypes.join(
       ', '
     )}. Max length: ${config.maxCommitLength}`;
+  }
+
+  if (/BREAKING CHANGE:/i.test(body)) {
+    return null;
   }
 
   return null;


### PR DESCRIPTION
- Validate commit body and footer, not just the title.
- Support BREAKING CHANGE in body or footer.
- Block temporary commits (WIP, fixup!, squash!).